### PR TITLE
Update membership pricing and improve presentation

### DIFF
--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -158,8 +158,7 @@ export default function Home() {
               </div>
               <p className={styles.membershipSummary}>Reserve 10 days in advance.</p>
               <div className={styles.membershipCta}>
-                <a href="https://the-rally-club-llc.square.site/product/a-list-monthly-membership/9" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join Monthly</a>
-                <a href="https://the-rally-club-llc.square.site/product/a-list-annual-membership/7" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join Yearly</a>
+                <a href="https://square.link/u/oybkGt7O?src=embed" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join A-List</a>
               </div>
               <div className={styles.pricingDetails}>
                 <h4>Court Rates:</h4>

--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -204,7 +204,7 @@ export default function Home() {
                   </table>
                 </div>
                 <div className={`${styles.rateItem} ${styles.baseRate}`}>
-                  <span className={styles.rateTime}>Sat-Sun all day</span>
+                  <span className={styles.rateTime}>Weekends — All Day</span>
                   <span className={styles.ratePrice}>$40/hr</span>
                 </div>
               </div>

--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -148,18 +148,31 @@ export default function Home() {
               <div className={styles.bestValueBadge}>BEST VALUE</div>
               <h3 className={styles.membershipTitle}>A-List</h3>
               <div className={styles.membershipPrice}>
-                <div style={{ marginBottom: '0.5rem' }}>
-                  <span className={styles.price}>$35</span>
-                  <span className={styles.period}>/month</span>
-                </div>
-                <div style={{ fontSize: '1.2rem', color: '#666' }}>
-                  or <span style={{ fontWeight: 'bold', color: '#333' }}>$350</span>/year
+                <div style={{ display: 'flex', gap: '2rem', justifyContent: 'center', alignItems: 'flex-end', flexWrap: 'wrap' }}>
+                  <div style={{ textAlign: 'center' }}>
+                    <div style={{ fontSize: '0.9rem', color: '#666', marginBottom: '0.25rem', textTransform: 'uppercase', fontWeight: '600' }}>Monthly</div>
+                    <div>
+                      <span className={styles.price}>$35</span>
+                      <span className={styles.period}>/mo</span>
+                    </div>
+                  </div>
+                  <div style={{ height: '5rem', width: '1px', background: '#ddd', alignSelf: 'center' }}></div>
+                  <div style={{ textAlign: 'center' }}>
+                    <div style={{ marginBottom: '0.25rem' }}>
+                      <span style={{ background: '#4CAF50', color: 'white', fontSize: '0.7rem', padding: '3px 8px', borderRadius: '10px', fontWeight: 'bold' }}>Save 17%</span>
+                    </div>
+                    <div style={{ fontSize: '0.9rem', color: '#666', marginBottom: '0.25rem', textTransform: 'uppercase', fontWeight: '600' }}>Annual</div>
+                    <div>
+                      <span className={styles.price}>$350</span>
+                      <span className={styles.period}>/yr</span>
+                    </div>
+                  </div>
                 </div>
               </div>
               <p className={styles.membershipSummary}>Reserve 10 days in advance.</p>
               <div className={styles.membershipCta}>
-                <a href="https://the-rally-club-llc.square.site/product/a-list-monthly-membership/9" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join Monthly</a>
-                <a href="https://the-rally-club-llc.square.site/product/a-list-annual-membership/7" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join Yearly</a>
+                <a href="https://square.link/u/EKztnz5s" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join A-List Monthly</a>
+                <a href="https://square.link/u/ram1LVxm" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join A-List Annually</a>
               </div>
               <div className={styles.pricingDetails}>
                 <h4>Court Rates:</h4>

--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -186,16 +186,25 @@ export default function Home() {
               </div>
               <div className={styles.pricingDetails}>
                 <h4>Court Rates:</h4>
-                <div className={styles.rateItem}>
-                  <span className={styles.rateTime}>Every day 5am - 8am</span>
-                  <span className={styles.ratePrice}>$16/hr</span>
-                </div>
-                <div className={styles.rateItem}>
-                  <span className={styles.rateTime}>Every day 8am - 4pm</span>
-                  <span className={styles.ratePrice}>$20/hr</span>
+                <div className={styles.rateTableWrapper}>
+                  <table className={styles.rateTable}>
+                    <tbody>
+                      <tr>
+                        <th rowSpan="2">Weekdays</th>
+                        <th>12am - 8am</th>
+                        <th>8am - 4pm</th>
+                        <th>4pm - 12am</th>
+                      </tr>
+                      <tr>
+                        <td>$16/hr</td>
+                        <td>$20/hr</td>
+                        <td>$35/hr</td>
+                      </tr>
+                    </tbody>
+                  </table>
                 </div>
                 <div className={`${styles.rateItem} ${styles.baseRate}`}>
-                  <span className={styles.rateTime}>All other times</span>
+                  <span className={styles.rateTime}>Sat-Sun all day</span>
                   <span className={styles.ratePrice}>$40/hr</span>
                 </div>
               </div>
@@ -216,27 +225,47 @@ export default function Home() {
           </div>
         </section>
 
-        {/* Special Programs */}
+        {/* A-List Seniors */}
         <section className={styles.specialProgramsSection}>
-          <h2 className={styles.sectionTitle}>Special Programs</h2>
+          <h2 className={styles.sectionTitle}>A-List Seniors</h2>
           <div className={styles.specialProgramsIntro}>
             <p>Rally Club partners with Medicare and Medicaid programs to make pickleball accessible to more players. These special membership tiers require eligibility verification and admin approval.</p>
           </div>
           <div className={styles.specialProgramsPricing}>
-            <h3>Court Rates for Special Programs</h3>
+            <h3>Court Rates for A-List Seniors</h3>
             <p className={styles.membershipSummary}>Reserve 7 days in advance.</p>
             <div className={styles.specialPricingGrid}>
-              <div className={styles.rateItem}>
-                <span className={styles.rateTime}>Weekdays 7am - 4pm</span>
-                <span className={styles.ratePrice}>FREE</span>
+              <div className={styles.rateTableWrapper}>
+                <table className={styles.rateTable}>
+                  <tbody>
+                    <tr>
+                      <th rowSpan="2">Weekdays</th>
+                      <th>12am - 7am</th>
+                      <th>7am - 4pm</th>
+                      <th>4pm - 12am</th>
+                    </tr>
+                    <tr>
+                      <td>$20/hr</td>
+                      <td>FREE</td>
+                      <td>$28/hr</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
-              <div className={styles.rateItem}>
-                <span className={styles.rateTime}>Weekends 9am - 4pm</span>
-                <span className={styles.ratePrice}>$20</span>
-              </div>
-              <div className={styles.rateItem}>
-                <span className={styles.rateTime}>All other times</span>
-                <span className={styles.ratePrice}>$28</span>
+              <div className={styles.rateTableWrapper}>
+                <table className={styles.rateTable}>
+                  <tbody>
+                    <tr>
+                      <th rowSpan="2">Weekends</th>
+                      <th>12am - 4pm</th>
+                      <th>4pm - 12am</th>
+                    </tr>
+                    <tr>
+                      <td>$20/hr</td>
+                      <td>$28/hr</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>

--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -158,8 +158,8 @@ export default function Home() {
               </div>
               <p className={styles.membershipSummary}>Reserve 10 days in advance.</p>
               <div className={styles.membershipCta}>
-                <a href="https://square.link/u/LcxQzlsY" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join Monthly</a>
-                <a href="https://square.link/u/EU8yAr7I" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join Yearly</a>
+                <a href="https://the-rally-club-llc.square.site/product/a-list-monthly-membership/9" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join Monthly</a>
+                <a href="https://the-rally-club-llc.square.site/product/a-list-annual-membership/7" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join Yearly</a>
               </div>
               <div className={styles.pricingDetails}>
                 <h4>Court Rates:</h4>

--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -198,7 +198,7 @@ export default function Home() {
                       <tr>
                         <td>$16/hr</td>
                         <td>$20/hr</td>
-                        <td>$35/hr</td>
+                        <td>$40/hr</td>
                       </tr>
                     </tbody>
                   </table>

--- a/site/styles/Index.module.css
+++ b/site/styles/Index.module.css
@@ -309,7 +309,7 @@
   max-width: 100%;
 }
 
-/* Special Programs Section */
+/* A-List Seniors Section */
 .specialProgramsSection {
   padding: 3rem 2rem;
   background: #f3e5f5;
@@ -492,6 +492,56 @@
   color: #333;
   margin-bottom: 1rem;
   text-align: center;
+}
+
+.rateTableWrapper {
+  background: #f8f9fa;
+  border-radius: 6px;
+  border-left: 3px solid #FF6600;
+  margin-bottom: 0.5rem;
+  overflow: hidden;
+}
+
+.rateTable {
+  width: 100%;
+  border-collapse: collapse;
+  background: #f8f9fa;
+}
+
+.rateTable th {
+  background: #f8f9fa;
+  color: #333;
+  padding: 0.75rem 0.5rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+.rateTable th:first-child {
+  background: #f8f9fa;
+  color: #555;
+  font-size: 0.95rem;
+  font-weight: 700;
+  border-bottom: none;
+}
+
+.rateTable tr:first-child th {
+  border-bottom: 1px solid #dee2e6;
+}
+
+.rateTable tr:first-child th:first-child {
+  border-bottom: none;
+  border-right: 1px solid #dee2e6;
+}
+
+.rateTable td {
+  padding: 0.75rem 0.5rem;
+  text-align: center;
+  font-weight: 700;
+  color: #FF6600;
+  background: #f8f9fa;
+  font-size: 1rem;
+  border-top: 1px solid #dee2e6;
 }
 
 .rateItem {


### PR DESCRIPTION
## Summary
- Improved A-List membership pricing display with side-by-side Monthly ($35/mo) and Annual ($350/yr) options
- Added "Save 17%" badge to highlight annual membership savings
- Restructured Rally Reserve and A-List Seniors court rates using pricing tables for better clarity
- Updated Square payment links for A-List membership purchases
- Renamed "Special Programs" to "A-List Seniors" for clearer branding

## Changes

### A-List Membership
- Split pricing display into two columns (Monthly vs Annual)
- Added visual separator and savings badge
- Updated button labels: "Join A-List Monthly" and "Join A-List Annually"
- Updated Square links to new payment URLs

### Rally Reserve Court Rates
- Converted simple list to structured pricing table
- Weekdays: $16 (12am-8am), $20 (8am-4pm), $40 (4pm-12am)
- Weekends: $40/hr all day

### A-List Seniors
- Renamed section from "Special Programs" to "A-List Seniors"
- Added two pricing tables (Weekdays and Weekends)
- Weekdays: $20 (12am-7am), FREE (7am-4pm), $28 (4pm-12am)
- Weekends: $20 (12am-4pm), $28 (4pm-12am)

### Styling
- Added rate table CSS with orange accent borders
- Improved mobile responsiveness for pricing displays
- Enhanced visual hierarchy with better typography

## Test plan
- [ ] Verify A-List membership pricing displays correctly on desktop and mobile
- [ ] Test Square payment links for monthly and annual memberships
- [ ] Confirm pricing tables are readable on all screen sizes
- [ ] Check that "Save 17%" badge displays correctly
- [ ] Verify A-List Seniors section renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)