### PR TITLE
Update Honcho League for Early Spring 2026 season

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ site/                    # Main project directory
 - Detailed information about Honcho Pickleball League
 - Two competition formats: Doubles and Ladder League
 - Registration information with discount code RALLYCLUB
-- External registration link: https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-winter-2026/
+- External registration link: https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-early-spring-26/
 
 #### Rally Experiences Page (`pages/rally-experiences.js`)
 - Corporate team building and private event packages
@@ -102,7 +102,7 @@ Hero video was optimized using ffmpeg:
 
 ## External Integrations
 - **PicklePlanner**: Court reservation system (https://rallyclub.pickleplanner.com)
-- **Honcho Pickleball**: League registration (https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-winter-2026/)
+- **Honcho Pickleball**: League registration (https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-early-spring-26/)
 - **Square**: Payment processing for A-List membership and merchandise shop
 - **Square Shop**: Embedded merchandise store (https://the-rally-club-llc.square.site)
 - **Google Maps**: Location and directions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ site/                    # Main project directory
 #### Main Landing Page (`pages/index.js`)
 - **Hero Section**: Reversed video background (`club_interior_reversed_optimized.mp4`)
 - **Membership Tiers**: A-List ($35/mo or $350/year) and Rally Reserve (free) with pricing details
-- **Honcho League Section**: Registration CTA with discount code RALLYCLUB
+- **Honcho League Section**: Registration CTA with discount code Hawkes
 - **Rally Experiences Section**: Link to corporate team building and private events
 - **Facility Overview**: Interactive image gallery with lightbox
 - **Booking Process**: 4-step process visualization
@@ -65,7 +65,7 @@ site/                    # Main project directory
 #### Honcho League Page (`pages/honcho.js`)
 - Detailed information about Honcho Pickleball League
 - Two competition formats: Doubles and Ladder League
-- Registration information with discount code RALLYCLUB
+- Registration information with discount code Hawkes
 - External registration link: https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-early-spring-26/
 
 #### Rally Experiences Page (`pages/rally-experiences.js`)
@@ -128,7 +128,7 @@ The site includes comprehensive SEO setup with:
 
 ## Important Notes
 - All players must be registered with PicklePlanner before playing
-- Discount code for Honcho League: **RALLYCLUB**
+- Discount code for Honcho League: **Hawkes**
 - Rally Experiences contact: rental@rallyclubpickleball.com or (618) 931-0015
 - General inquiries: rally.club618@gmail.com
 - Video files in `site/public/` are large - ensure they're optimized before committing

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a Next.js-based website that showcases Rally Club Pickleball's facility,
 
 - 🎥 **Video Hero Section** - Reversed and optimized club interior footage as background
 - 💳 **Membership Tiers** - A-List ($35/mo or $350/year) and Rally Reserve (free) with integrated Square checkout
-- 🏆 **Honcho League Integration** - Dedicated page for Honcho Pickleball League with exclusive RALLYCLUB discount code
+- 🏆 **Honcho League Integration** - Dedicated page for Honcho Pickleball League with exclusive Hawkes discount code
 - 🎯 **Rally Experiences** - Corporate team building and private event packages with guided pickleball experiences
 - 🛍️ **Merchandise Shop** - Embedded Square Shop for Rally Club apparel and gear
 - 🏐 **Facility Overview** - Interactive image gallery with lightbox modal
@@ -131,7 +131,7 @@ Dedicated page (`/honcho`) featuring:
 - Two competition formats: Doubles League and Ladder League
 - Registration information with dates and early bird pricing
 - Community benefits and season structure
-- Discount code: **RALLYCLUB** for Rally Club members
+- Discount code: **Hawkes** for Rally Club members
 
 ### Rally Experiences
 Dedicated page (`/rally-experiences`) for corporate team building and private events:
@@ -167,7 +167,7 @@ No environment variables required for basic functionality.
 
 ### External Integrations
 - **PicklePlanner**: Court booking system (https://rallyclub.pickleplanner.com)
-- **Honcho Pickleball**: League registration (https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-early-spring-26/) - Use code: **RALLYCLUB**
+- **Honcho Pickleball**: League registration (https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-early-spring-26/) - Use code: **Hawkes**
 - **Square**: Payment processing for A-List membership and merchandise shop
 - **Square Shop**: Embedded merchandise store (https://the-rally-club-llc.square.site)
 - **Google Maps**: Location and directions

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ No environment variables required for basic functionality.
 
 ### External Integrations
 - **PicklePlanner**: Court booking system (https://rallyclub.pickleplanner.com)
-- **Honcho Pickleball**: League registration (https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-winter-2026/) - Use code: **RALLYCLUB**
+- **Honcho Pickleball**: League registration (https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-early-spring-26/) - Use code: **RALLYCLUB**
 - **Square**: Payment processing for A-List membership and merchandise shop
 - **Square Shop**: Embedded merchandise store (https://the-rally-club-llc.square.site)
 - **Google Maps**: Location and directions

--- a/site/pages/honcho.js
+++ b/site/pages/honcho.js
@@ -112,7 +112,15 @@ export default function Honcho() {
             <div className="detail-card">
               <div className="detail-icon">👥</div>
               <h3>Format & Schedule</h3>
-              <p>2–4 players per team. 8-week season runs March 4 - April 29, 2026 with 7 guaranteed DUPR-eligible matches + playoffs.</p>
+              <ul style={{ textAlign: 'left', margin: 0, paddingLeft: '1.2rem', fontSize: '0.95rem', lineHeight: '1.6', color: '#666' }}>
+                <li>2–4 players per team</li>
+                <li>8-week season
+                  <ul style={{ paddingLeft: '1rem', marginTop: '0.25rem' }}>
+                    <li>March 4 - April 29, 2026</li>
+                  </ul>
+                </li>
+                <li>7 guaranteed DUPR-eligible matches</li>
+              </ul>
             </div>
             <div className="detail-card">
               <div className="detail-icon">🏆</div>
@@ -122,7 +130,7 @@ export default function Honcho() {
             <div className="detail-card">
               <div className="detail-icon">✅</div>
               <h3>Registration</h3>
-              <p><strong>Early Bird:</strong> Jan 12 - Jan 25<br /><strong>Regular:</strong> Jan 25 - Feb 15<br /><strong>Use code Hawkes</strong> for savings!</p>
+              <p><strong>Early Bird:</strong> Jan 12 - Jan 25, 2026<br /><strong>Regular:</strong> Jan 25 - Feb 15, 2026<br /><strong>Use code <span style={{ textDecoration: 'underline' }}>Hawkes</span></strong> for savings!</p>
             </div>
           </div>
         </section>

--- a/site/pages/honcho.js
+++ b/site/pages/honcho.js
@@ -12,7 +12,7 @@ export default function Honcho() {
         <title>Honcho Pickleball League | Rally Club Pickleball</title>
         <meta
           name="description"
-          content="Join the Honcho Pickleball League - the premier amateur pickleball community with doubles league format. Season starts March 2, 2026. Registration closes Feb 15, 2026."
+          content="Join the Honcho Pickleball League - the premier amateur pickleball community with doubles league format. Season runs March 4 - April 29, 2026. Early bird registration Jan 12-25."
         />
         <link rel="canonical" href="https://www.rallyclubpickleball.com/honcho" />
         <meta
@@ -101,7 +101,7 @@ export default function Honcho() {
               <a href="https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-early-spring-26/" className="honcho-cta-button" target="_blank" rel="noopener noreferrer">Register Now</a>
               <span className="honcho-hashtag">#HonchoFam</span>
             </div>
-            <p style={{ marginTop: '1rem', fontSize: '1rem', color: '#E8F5E8' }}>Use code <strong style={{ color: '#C8F560' }}>RALLYCLUB</strong> for extra savings!</p>
+            <p style={{ marginTop: '1rem', fontSize: '1rem', color: '#E8F5E8' }}>Use code <strong style={{ color: '#C8F560' }}>Hawkes</strong> for extra savings!</p>
           </div>
         </section>
 
@@ -112,7 +112,7 @@ export default function Honcho() {
             <div className="detail-card">
               <div className="detail-icon">👥</div>
               <h3>Format & Schedule</h3>
-              <p>2–4 players per team, 2 compete weekly. 8-week season starting March 2, 2026 with 7 guaranteed DUPR-eligible matches + playoffs.</p>
+              <p>2–4 players per team. 8-week season runs March 4 - April 29, 2026 with 7 guaranteed DUPR-eligible matches + playoffs.</p>
             </div>
             <div className="detail-card">
               <div className="detail-icon">🏆</div>
@@ -122,7 +122,7 @@ export default function Honcho() {
             <div className="detail-card">
               <div className="detail-icon">✅</div>
               <h3>Registration</h3>
-              <p><strong>Closes Feb 15, 2026 at 11:59PM</strong><br />Fully administered gameplay, court costs included<br /><strong>Use code RALLYCLUB</strong> for savings!</p>
+              <p><strong>Early Bird:</strong> Jan 12 - Jan 25<br /><strong>Regular:</strong> Jan 25 - Feb 15<br /><strong>Use code Hawkes</strong> for savings!</p>
             </div>
           </div>
         </section>
@@ -158,20 +158,11 @@ export default function Honcho() {
           </div>
         </section>
 
-        {/* Referral Perks */}
-        <section className="referral-section">
-          <div className="referral-content">
-            <div className="referral-icon">🎁</div>
-            <h2 className="referral-title">Referral Perks</h2>
-            <p className="referral-text">Recruit 3+ friends and earn rewards like a free JOOLA paddle, free entry & more (just have them list you during registration!)</p>
-          </div>
-        </section>
-
         {/* Call to Action */}
         <section className="final-cta">
           <div className="cta-content">
             <h2>Ready to Compete?</h2>
-            <p style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#C8F560', marginBottom: '2rem' }}>Use discount code <span style={{ fontSize: '1.3rem' }}>RALLYCLUB</span> for extra savings on top of early bird pricing!</p>
+            <p style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#C8F560', marginBottom: '2rem' }}>Use discount code <span style={{ fontSize: '1.3rem' }}>Hawkes</span> for extra savings on top of early bird pricing!</p>
             <div className="cta-buttons">
               <a href="https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-early-spring-26/" className="honcho-button primary large" target="_blank" rel="noopener noreferrer">Register for League</a>
             </div>

--- a/site/pages/honcho.js
+++ b/site/pages/honcho.js
@@ -95,7 +95,7 @@ export default function Honcho() {
             />
             <h1 className="honcho-hero-title">Same-Partner Doubles League</h1>
             <p className="honcho-hero-subtitle">
-              Team up with 2-4 players and compete in 7 DUPR-eligible matches plus playoffs. Battle for the Head Honcho Championship and win over $500 in prizes!
+              Team up with 2-4 players and compete in 7 guaranteed DUPR-eligible matches plus playoffs. Battle for the Head Honcho Championship and win over $500 in prizes!
             </p>
             <div className="honcho-hero-cta">
               <a href="https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-early-spring-26/" className="honcho-cta-button" target="_blank" rel="noopener noreferrer">Register Now</a>
@@ -112,7 +112,7 @@ export default function Honcho() {
             <div className="detail-card">
               <div className="detail-icon">👥</div>
               <h3>Format & Schedule</h3>
-              <p>2–4 players per team, 2 compete weekly. 8-week season starting March 2, 2026 with 7 DUPR-eligible matches + playoffs.</p>
+              <p>2–4 players per team, 2 compete weekly. 8-week season starting March 2, 2026 with 7 guaranteed DUPR-eligible matches + playoffs.</p>
             </div>
             <div className="detail-card">
               <div className="detail-icon">🏆</div>

--- a/site/pages/honcho.js
+++ b/site/pages/honcho.js
@@ -12,7 +12,7 @@ export default function Honcho() {
         <title>Honcho Pickleball League | Rally Club Pickleball</title>
         <meta
           name="description"
-          content="Join the Honcho Pickleball League - the premier amateur pickleball community with doubles and ladder league formats. Registration open Oct 13-Nov 16."
+          content="Join the Honcho Pickleball League - the premier amateur pickleball community with doubles league format. Season starts March 2, 2026. Registration closes Feb 15, 2026."
         />
         <link rel="canonical" href="https://www.rallyclubpickleball.com/honcho" />
         <meta
@@ -98,7 +98,7 @@ export default function Honcho() {
               Team up with 2-4 players and compete in 7 DUPR-eligible matches plus playoffs. Battle for the Head Honcho Championship and win over $500 in prizes!
             </p>
             <div className="honcho-hero-cta">
-              <a href="https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-winter-2026/" className="honcho-cta-button" target="_blank" rel="noopener noreferrer">Register Now</a>
+              <a href="https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-early-spring-26/" className="honcho-cta-button" target="_blank" rel="noopener noreferrer">Register Now</a>
               <span className="honcho-hashtag">#HonchoFam</span>
             </div>
             <p style={{ marginTop: '1rem', fontSize: '1rem', color: '#E8F5E8' }}>Use code <strong style={{ color: '#C8F560' }}>RALLYCLUB</strong> for extra savings!</p>
@@ -112,7 +112,7 @@ export default function Honcho() {
             <div className="detail-card">
               <div className="detail-icon">👥</div>
               <h3>Format & Schedule</h3>
-              <p>2–4 players per team, 2 compete weekly. 8-week season (Dec 1 start) with 7 DUPR-eligible matches + playoffs. Break: Dec 22 - Jan 4.</p>
+              <p>2–4 players per team, 2 compete weekly. 8-week season starting March 2, 2026 with 7 DUPR-eligible matches + playoffs.</p>
             </div>
             <div className="detail-card">
               <div className="detail-icon">🏆</div>
@@ -122,7 +122,7 @@ export default function Honcho() {
             <div className="detail-card">
               <div className="detail-icon">✅</div>
               <h3>Registration</h3>
-              <p><strong>Open through Nov 16</strong><br />Fully administered gameplay, court costs included<br /><strong>Use code RALLYCLUB</strong> for savings!</p>
+              <p><strong>Closes Feb 15, 2026 at 11:59PM</strong><br />Fully administered gameplay, court costs included<br /><strong>Use code RALLYCLUB</strong> for savings!</p>
             </div>
           </div>
         </section>
@@ -173,7 +173,7 @@ export default function Honcho() {
             <h2>Ready to Compete?</h2>
             <p style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#C8F560', marginBottom: '2rem' }}>Use discount code <span style={{ fontSize: '1.3rem' }}>RALLYCLUB</span> for extra savings on top of early bird pricing!</p>
             <div className="cta-buttons">
-              <a href="https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-winter-2026/" className="honcho-button primary large" target="_blank" rel="noopener noreferrer">Register for League</a>
+              <a href="https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-early-spring-26/" className="honcho-button primary large" target="_blank" rel="noopener noreferrer">Register for League</a>
             </div>
           </div>
         </section>

--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -377,7 +377,7 @@ export default function Home() {
               </div>
 
               <div className={styles.honchoCta}>
-                <a href="https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-winter-2026/" className={styles.honchoButton} target="_blank" rel="noopener noreferrer">
+                <a href="https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-early-spring-26/" className={styles.honchoButton} target="_blank" rel="noopener noreferrer">
                   Register Now (Use Code: RALLYCLUB)
                 </a>
                 <a href="/honcho" className={`${styles.honchoButton} ${styles.secondary}`}>

--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -378,7 +378,7 @@ export default function Home() {
 
               <div className={styles.honchoCta}>
                 <a href="https://honchopickleball.com/product/glen-carbon-il-the-rally-club-wednesdays-early-spring-26/" className={styles.honchoButton} target="_blank" rel="noopener noreferrer">
-                  Register Now (Use Code: RALLYCLUB)
+                  Register Now (Use Code: Hawkes)
                 </a>
                 <a href="/honcho" className={`${styles.honchoButton} ${styles.secondary}`}>
                   Learn More


### PR DESCRIPTION
## Summary
- Update Honcho registration links to Early Spring 2026 season URL
- Update season start date to March 2, 2026 (no break this season)
- Update registration deadline to Feb 15, 2026 at 11:59PM
- Update meta descriptions and documentation with new dates

## Test plan
- [ ] Verify registration links point to correct Early Spring 2026 URL
- [ ] Confirm season dates display correctly on /honcho page
- [ ] Check meta descriptions are updated

🤖 Generated with [Claude Code](https://claude.ai/code)