### PR TITLE
Add $20 sign-up fee and update A-List membership links

### DIFF
--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -284,8 +284,7 @@ export default function Home() {
               </div>
               <p className={styles.membershipSummary}>Reserve 10 days in advance.</p>
               <div className={styles.membershipCta}>
-                <a href="https://square.link/u/oybkGt7O" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join A-List Monthly</a>
-                <a href="https://square.link/u/h35UrlS4" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join A-List Annually</a>
+                <a href="https://square.link/u/oybkGt7O" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join A-List</a>
               </div>
               <div className={styles.pricingDetails}>
                 <h4>Court Rates:</h4>

--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -266,25 +266,26 @@ export default function Home() {
                 <div style={{ display: 'flex', gap: '2rem', justifyContent: 'center', alignItems: 'flex-end', flexWrap: 'wrap' }}>
                   <div style={{ textAlign: 'center' }}>
                     <div style={{ fontSize: '0.9rem', color: '#666', marginBottom: '0.25rem', textTransform: 'uppercase', fontWeight: '600' }}>Monthly</div>
-                    <div>
+                    <div className={styles.tooltip} data-tip="$20 one-time sign-up fee">
                       <span className={styles.price}>$35</span>
-                      <span className={styles.period}>/mo</span>
+                      <span className={styles.period}>/mo*</span>
                     </div>
                   </div>
                   <div style={{ height: '5rem', width: '1px', background: '#ddd', alignSelf: 'center' }}></div>
                   <div style={{ textAlign: 'center' }}>
                     <div style={{ fontSize: '0.9rem', marginBottom: '0.25rem', textTransform: 'uppercase', fontWeight: '600' }}><span style={{ color: '#666' }}>Annual</span> <span style={{ color: '#4CAF50' }}>&middot; Save 17%</span></div>
-                    <div>
+                    <div className={styles.tooltip} data-tip="$20 one-time sign-up fee">
                       <span className={styles.price}>$350</span>
-                      <span className={styles.period}>/yr</span>
+                      <span className={styles.period}>/yr*</span>
                     </div>
                   </div>
                 </div>
+                <div className={styles.signupFeeNote}>*$20 one-time sign-up fee</div>
               </div>
               <p className={styles.membershipSummary}>Reserve 10 days in advance.</p>
               <div className={styles.membershipCta}>
-                <a href="https://square.link/u/EKztnz5s" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join A-List Monthly</a>
-                <a href="https://square.link/u/ram1LVxm" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join A-List Annually</a>
+                <a href="https://square.link/u/oybkGt7O" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join A-List Monthly</a>
+                <a href="https://square.link/u/h35UrlS4" className={styles.membershipButton} target="_blank" rel="noopener noreferrer">Join A-List Annually</a>
               </div>
               <div className={styles.pricingDetails}>
                 <h4>Court Rates:</h4>

--- a/site/styles/Index.module.css
+++ b/site/styles/Index.module.css
@@ -492,6 +492,54 @@
   color: #666;
 }
 
+.tooltip {
+  position: relative;
+  cursor: help;
+}
+
+.tooltip::after {
+  content: attr(data-tip);
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  color: #fff;
+  padding: 0.4rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.1s;
+}
+
+.tooltip:hover::after {
+  opacity: 1;
+}
+
+.signupFeeNote {
+  display: none;
+  font-size: 0.8rem;
+  color: #888;
+  margin-top: 0.25rem;
+  text-align: center;
+}
+
+@media (max-width: 768px) {
+  .signupFeeNote {
+    display: block;
+  }
+
+  .tooltip::after {
+    display: none;
+  }
+
+  .price {
+    font-size: 2rem;
+  }
+}
+
 .membershipSummary {
   color: #666;
   font-size: 0.95rem;
@@ -1526,8 +1574,7 @@
   }
 
   .benefitIcon {
-    font-size: 1.5rem;
-    margin-bottom: 0.5rem;
+    display: none;
   }
 
   .benefitItem h3 {


### PR DESCRIPTION
## Summary
- Update Square payment links for monthly and annual A-List membership to new links that include $20 sign-up fee
- Add hover tooltip on desktop showing fee details on price asterisks
- Visible fee text fallback on mobile (no hover available)
- Reduce price font size on mobile for single-line fit
- Hide benefit emoji icons on mobile to save space

## Test plan
- [ ] Verify new Square links open correct payment pages
- [ ] Hover over prices on desktop to confirm tooltip appears instantly
- [ ] Check mobile view shows fee text and prices fit on one line
- [ ] Confirm benefit icons hidden on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)